### PR TITLE
Add generic OAuth error handling to callback

### DIFF
--- a/lib/omniauth/strategies/lti.rb
+++ b/lib/omniauth/strategies/lti.rb
@@ -2,26 +2,35 @@ module OmniAuth
   module Strategies
     class Lti
       include OmniAuth::Strategy
-      
+
       # Hash for storing your Consumer Tools credentials, whether:
-      # - the key is the consumer_key 
+      # - the key is the consumer_key
       # - the value is the comsumer_secret
       option :oauth_credentials, {}
-      
+
       # Defaul username for users when LTI context doesn't provide a name
       option :default_user_name, 'User'
-      
+
       def callback_phase
         # validate request
         return fail!(:invalid_credentials) unless valid_lti?
         #save the launch parameters for use in later request
         env['lti.launch_params'] = @tp.to_params
         super
+      # rescue more generic OAuth errors and scenarios
+      rescue ::Timeout::Error
+        fail!(:timeout)
+      rescue ::Net::HTTPFatalError, ::OpenSSL::SSL::SSLError
+        fail!(:service_unavailable)
+      rescue ::OAuth::Unauthorized
+        fail!(:invalid_credentials)
+      rescue ::OmniAuth::NoSessionError
+        fail!(:session_expired)
       end
-      
+
       # define the UID
       uid { @tp.user_id }
-      
+
       # define the hash of info about user
       info do
         {
@@ -32,7 +41,7 @@ module OmniAuth
           :image => @tp.user_image
         }
       end
-      
+
       # define the hash of credentials
       credentials do
         {
@@ -40,14 +49,14 @@ module OmniAuth
           :secret => @tp.consumer_secret
         }
       end
-      
+
       #define extra hash
       extra do
         { :raw_info => @tp.to_params }
       end
-      
+
       private
-      
+
       def valid_lti?
         key = request.params['oauth_consumer_key']
         log :info, "Checking LTI params for key #{key}: #{request.params}"


### PR DESCRIPTION
to make LTI certification testing happy. One of the LTI conformance tests covers an invalid OAuth signature. Omniauth Strategies have a general way to rescue from errors in callback, so this adds that case (`::OAuth::Unauthorized`) along with several other OAuth common error cases.
